### PR TITLE
Refactor DSL to use typed project targets

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -7,64 +7,57 @@ import { copyFile, mkdir, deleteFile, exec } from "../src/common/index.ts";
 import { javac, jar, java } from "../src/java/index.ts";
 
 // Define a project with multiple targets
-const app = project("app", (p) => {
+const app = project("app")
   // Clean target - removes build artifacts
-  p.target("clean", () => {
+  .target("clean", () => {
     deleteFile({
       paths: ["build", "dist"],
     });
-  });
-
+  })
   // Init target - creates necessary directories
-  p.target("init", ["clean"], () => {
+  .target("init", ["clean"], () => {
     mkdir({
       paths: ["build/classes", "dist"],
     });
-  });
-
+  })
   // Compile target - compiles Java source files
-  p.target("compile", ["init"], () => {
+  .target("compile", ["init"], () => {
     javac({
       srcFiles: ["src/**/*.java"], // Would need actual Java files
       destDir: "build/classes",
       source: "11",
       target: "11",
     });
-  });
-
+  })
   // Package target - creates a JAR file
-  p.target("package", ["compile"], () => {
+  .target("package", ["compile"], () => {
     jar({
       jarFile: "dist/app.jar",
       baseDir: "build/classes",
       mainClass: "com.example.Main",
     });
-  });
-
+  })
   // Build target - full build process
-  p.target("build", ["package"], () => {
+  .target("build", ["package"], () => {
     copyFile({
       from: ["README.md", "LICENSE"],
       to: "dist/",
     });
-  });
-
+  })
   // Run target - runs the application
-  p.target("run", ["build"], () => {
+  .target("run", ["build"], () => {
     java({
       jar: "dist/app.jar",
     });
-  });
-
+  })
   // Test target - runs tests
-  p.target("test", ["compile"], () => {
+  .target("test", ["compile"], () => {
     exec({
       command: "echo",
       args: ["Running tests..."],
     });
     // In a real project, you would run JUnit or other test frameworks
   });
-});
 
 // Execute the build target
 console.log("=== Worklift Build Tool ===\n");

--- a/examples/simple-deps-test.ts
+++ b/examples/simple-deps-test.ts
@@ -8,44 +8,39 @@ import { project } from "../src/index.ts";
 const executionOrder: string[] = [];
 
 // Project A - no dependencies
-const projectA = project("projectA", (p) => {
-  p.target("build", () => {
+const projectA = project("projectA")
+  .target("build", () => {
     executionOrder.push("projectA:build");
   });
-});
 
 // Project B - depends on Project A
-const projectB = project("projectB", (p) => {
-  p.dependsOn(projectA);
-
-  p.target("build", () => {
+const projectB = project("projectB")
+  .target("build", () => {
     executionOrder.push("projectB:build");
   });
-});
+
+projectB.dependsOn(projectA);
 
 // Project C - target depends on projectA:build
-const projectC = project("projectC", (p) => {
-  p.target("build", [[projectA, "build"]], () => {
+const projectC = project("projectC")
+  .target("build", [projectA.target("build")], () => {
     executionOrder.push("projectC:build");
   });
-});
 
 // Project D - multiple dependency types
-const projectD = project("projectD", (p) => {
-  // Project-level dependency on B
-  p.dependsOn(projectB);
-
-  p.target("clean", () => {
+const projectD = project("projectD")
+  .target("clean", () => {
     executionOrder.push("projectD:clean");
-  });
-
+  })
   // Target with mixed dependencies:
   // - "clean": local target
-  // - [projectC, "build"]: cross-project target
-  p.target("build", ["clean", [projectC, "build"]], () => {
+  // - projectC.target("build"): cross-project target
+  .target("build", ["clean", projectC.target("build")], () => {
     executionOrder.push("projectD:build");
   });
-});
+
+// Project-level dependency on B
+projectD.dependsOn(projectB);
 
 // Execute and verify order
 await projectD.execute("build");

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -55,16 +55,6 @@ export interface Target {
 }
 
 /**
- * Options for creating a project
- */
-export interface ProjectOptions {
-  /** Project name */
-  name: string;
-  /** Dependencies on other projects or targets */
-  dependsOn?: Dependency[];
-}
-
-/**
  * A project contains multiple targets
  */
 export interface Project {
@@ -76,10 +66,10 @@ export interface Project {
   targets: Map<string, Target>;
   /** Get a target reference by name */
   target(name: string): Target;
-  /** Define a new target */
-  target(name: string, fn: () => void): Target;
-  /** Define a new target with dependencies */
-  target(name: string, dependencies: Dependency[], fn: () => void): Target;
+  /** Define a new target (returns Project for chaining) */
+  target(name: string, fn: () => void): Project;
+  /** Define a new target with dependencies (returns Project for chaining) */
+  target(name: string, dependencies: Dependency[], fn: () => void): Project;
   /** Execute a target by name */
   execute(targetName: string): Promise<void>;
   /** Add a project dependency */
@@ -90,18 +80,6 @@ export interface Project {
  * Global registry of projects
  */
 export const projects = new Map<string, Project>();
-
-/**
- * Currently active project (for task registration)
- */
-export let currentProject: Project | null = null;
-
-/**
- * Set the current project
- */
-export function setCurrentProject(project: Project | null) {
-  currentProject = project;
-}
 
 /**
  * Currently active target (for task registration)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@
 export { project } from "./core/project.ts";
 export type {
   Project,
-  ProjectOptions,
   Target,
   Dependency,
   TaskOptions,


### PR DESCRIPTION
Changes:
- Remove callback parameter from project() function
- Make target() return Project for method chaining
- Update all examples to use new fluent API
- Remove ProjectOptions interface (no longer needed)
- Remove currentProject context tracking
- Update README with new API examples

Breaking changes:
- Old: project("app", (p) => { p.target(...) })
- New: project("app").target(...).target(...)

The new API is more concise and provides better TypeScript type inference while maintaining all existing functionality for dependencies and target references.