### PR TITLE
Add glob pattern support to DeleteTask

### DIFF
--- a/packages/file-tasks/src/DeleteTask.test.ts
+++ b/packages/file-tasks/src/DeleteTask.test.ts
@@ -1,0 +1,185 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { DeleteTask } from "./DeleteTask";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+
+describe("DeleteTask with patterns", () => {
+  beforeEach(() => {
+    mkdirSync("test-temp/build/sub", { recursive: true });
+    mkdirSync("test-temp/build/test", { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync("test-temp", { recursive: true, force: true });
+  });
+
+  test("deletes files matching pattern", async () => {
+    writeFileSync("test-temp/build/file.txt", "content");
+    writeFileSync("test-temp/build/file.tmp", "content");
+    writeFileSync("test-temp/build/sub/file.tmp", "content");
+
+    await DeleteTask.patterns("**/*.tmp")
+      .baseDir("test-temp/build")
+      .execute();
+
+    expect(existsSync("test-temp/build/file.txt")).toBe(true);
+    expect(existsSync("test-temp/build/file.tmp")).toBe(false);
+    expect(existsSync("test-temp/build/sub/file.tmp")).toBe(false);
+  });
+
+  test("deletes multiple patterns", async () => {
+    writeFileSync("test-temp/build/file.tmp", "content");
+    writeFileSync("test-temp/build/file.bak", "content");
+    writeFileSync("test-temp/build/file.txt", "content");
+
+    await DeleteTask.patterns("**/*.tmp", "**/*.bak")
+      .baseDir("test-temp/build")
+      .execute();
+
+    expect(existsSync("test-temp/build/file.txt")).toBe(true);
+    expect(existsSync("test-temp/build/file.tmp")).toBe(false);
+    expect(existsSync("test-temp/build/file.bak")).toBe(false);
+  });
+
+  test("preserves files that don't match pattern", async () => {
+    writeFileSync("test-temp/build/file1.txt", "content");
+    writeFileSync("test-temp/build/file2.js", "content");
+    writeFileSync("test-temp/build/file3.tmp", "content");
+    writeFileSync("test-temp/build/sub/file4.txt", "content");
+
+    await DeleteTask.patterns("**/*.tmp")
+      .baseDir("test-temp/build")
+      .execute();
+
+    expect(existsSync("test-temp/build/file1.txt")).toBe(true);
+    expect(existsSync("test-temp/build/file2.js")).toBe(true);
+    expect(existsSync("test-temp/build/file3.tmp")).toBe(false);
+    expect(existsSync("test-temp/build/sub/file4.txt")).toBe(true);
+  });
+
+  test("deletes files in nested directories", async () => {
+    mkdirSync("test-temp/build/sub/nested", { recursive: true });
+    writeFileSync("test-temp/build/file.log", "content");
+    writeFileSync("test-temp/build/sub/file.log", "content");
+    writeFileSync("test-temp/build/sub/nested/file.log", "content");
+
+    await DeleteTask.patterns("**/*.log")
+      .baseDir("test-temp/build")
+      .execute();
+
+    expect(existsSync("test-temp/build/file.log")).toBe(false);
+    expect(existsSync("test-temp/build/sub/file.log")).toBe(false);
+    expect(existsSync("test-temp/build/sub/nested/file.log")).toBe(false);
+  });
+
+  test("works without baseDir (uses cwd)", async () => {
+    mkdirSync("test-temp/target", { recursive: true });
+    writeFileSync("test-temp/target/file.tmp", "content");
+    writeFileSync("test-temp/target/file.txt", "content");
+
+    await DeleteTask.patterns("test-temp/target/**/*.tmp").execute();
+
+    expect(existsSync("test-temp/target/file.txt")).toBe(true);
+    expect(existsSync("test-temp/target/file.tmp")).toBe(false);
+  });
+
+  test("deletes matched directories when includeDirs is true", async () => {
+    mkdirSync("test-temp/build/test-dir", { recursive: true });
+    mkdirSync("test-temp/build/prod-dir", { recursive: true });
+    writeFileSync("test-temp/build/test-dir/file.txt", "content");
+
+    await DeleteTask.patterns("**/test-*")
+      .baseDir("test-temp/build")
+      .includeDirs(true)
+      .execute();
+
+    expect(existsSync("test-temp/build/test-dir")).toBe(false);
+    expect(existsSync("test-temp/build/prod-dir")).toBe(true);
+  });
+
+  test("preserves directories when includeDirs is false", async () => {
+    mkdirSync("test-temp/build/test-dir", { recursive: true });
+    writeFileSync("test-temp/build/file.tmp", "content");
+
+    await DeleteTask.patterns("**/*.tmp")
+      .baseDir("test-temp/build")
+      .includeDirs(false)
+      .execute();
+
+    expect(existsSync("test-temp/build/file.tmp")).toBe(false);
+    expect(existsSync("test-temp/build/test-dir")).toBe(true);
+  });
+
+  test("throws error when neither paths nor patterns are provided", async () => {
+    const task = new DeleteTask();
+
+    expect(() => task.validate()).toThrow(
+      "DeleteTask: 'paths' or 'patterns' is required"
+    );
+  });
+});
+
+describe("DeleteTask with paths (backward compatibility)", () => {
+  beforeEach(() => {
+    mkdirSync("test-temp/build", { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync("test-temp", { recursive: true, force: true });
+  });
+
+  test("deletes specific paths", async () => {
+    writeFileSync("test-temp/build/file1.txt", "content");
+    writeFileSync("test-temp/build/file2.txt", "content");
+
+    await DeleteTask.paths(
+      "test-temp/build/file1.txt",
+      "test-temp/build/file2.txt"
+    ).execute();
+
+    expect(existsSync("test-temp/build/file1.txt")).toBe(false);
+    expect(existsSync("test-temp/build/file2.txt")).toBe(false);
+  });
+
+  test("deletes directories recursively", async () => {
+    mkdirSync("test-temp/build/subdir", { recursive: true });
+    writeFileSync("test-temp/build/subdir/file.txt", "content");
+
+    await DeleteTask.paths("test-temp/build/subdir")
+      .recursive(true)
+      .execute();
+
+    expect(existsSync("test-temp/build/subdir")).toBe(false);
+  });
+
+  test("handles non-existent paths gracefully (force: true)", async () => {
+    await DeleteTask.paths("test-temp/build/non-existent.txt").execute();
+
+    // Should not throw an error due to force: true
+    expect(true).toBe(true);
+  });
+});
+
+describe("DeleteTask mixed usage", () => {
+  beforeEach(() => {
+    mkdirSync("test-temp/build", { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync("test-temp", { recursive: true, force: true });
+  });
+
+  test("can use both paths and patterns together", async () => {
+    writeFileSync("test-temp/build/specific.txt", "content");
+    writeFileSync("test-temp/build/file.tmp", "content");
+    writeFileSync("test-temp/build/file.bak", "content");
+
+    const task = DeleteTask.patterns("**/*.tmp")
+      .baseDir("test-temp/build")
+      .execute();
+
+    await task;
+
+    expect(existsSync("test-temp/build/file.tmp")).toBe(false);
+    expect(existsSync("test-temp/build/file.bak")).toBe(true);
+  });
+});

--- a/packages/file-tasks/src/DeleteTask.ts
+++ b/packages/file-tasks/src/DeleteTask.ts
@@ -1,12 +1,16 @@
 import { Task } from "@worklift/core";
 import { rm } from "fs/promises";
+import { glob } from "glob";
 
 /**
  * Task for deleting files or directories
  */
 export class DeleteTask extends Task {
   private pathList?: string[];
+  private patternList?: string[];
+  private baseDirPath?: string;
   private recursiveFlag = true;
+  private includeDirsFlag = false;
 
   inputs?: string | string[];
   outputs?: string | string[];
@@ -17,21 +21,69 @@ export class DeleteTask extends Task {
     return task;
   }
 
+  static patterns(...patterns: string[]): DeleteTask {
+    const task = new DeleteTask();
+    task.patternList = patterns;
+    return task;
+  }
+
+  baseDir(dir: string): this {
+    this.baseDirPath = dir;
+    return this;
+  }
+
   recursive(value: boolean): this {
     this.recursiveFlag = value;
     return this;
   }
 
+  includeDirs(value: boolean): this {
+    this.includeDirsFlag = value;
+    return this;
+  }
+
   validate() {
-    if (!this.pathList || this.pathList.length === 0) {
-      throw new Error("DeleteTask: 'paths' is required");
+    if (
+      (!this.pathList || this.pathList.length === 0) &&
+      (!this.patternList || this.patternList.length === 0)
+    ) {
+      throw new Error("DeleteTask: 'paths' or 'patterns' is required");
     }
   }
 
   async execute() {
-    console.log(`  ↳ Deleting ${this.pathList!.length} item(s)`);
-    for (const path of this.pathList!) {
-      await rm(path, { recursive: this.recursiveFlag, force: true });
+    // Delete explicit paths (existing behavior)
+    if (this.pathList && this.pathList.length > 0) {
+      console.log(`  ↳ Deleting ${this.pathList.length} item(s)`);
+      for (const path of this.pathList) {
+        await rm(path, { recursive: this.recursiveFlag, force: true });
+      }
+    }
+
+    // Delete files matching patterns (new behavior)
+    if (this.patternList && this.patternList.length > 0) {
+      await this.deleteMatchingPatterns();
+    }
+  }
+
+  private async deleteMatchingPatterns() {
+    const cwd = this.baseDirPath || process.cwd();
+
+    for (const pattern of this.patternList!) {
+      const matches = await glob(pattern, {
+        cwd,
+        nodir: !this.includeDirsFlag,
+        absolute: true,
+      });
+
+      console.log(`  ↳ Deleting ${matches.length} file(s) matching ${pattern}`);
+
+      for (const file of matches) {
+        await rm(file, {
+          recursive: this.recursiveFlag,
+          force: true,
+        });
+      }
     }
   }
 }

--- a/packages/file-tasks/src/file-tasks.test.ts
+++ b/packages/file-tasks/src/file-tasks.test.ts
@@ -223,9 +223,9 @@ describe("File Tasks", () => {
       expect(task).toBeInstanceOf(DeleteTask);
     });
 
-    test("validates paths parameter is required", () => {
+    test("validates paths or patterns parameter is required", () => {
       const task = new DeleteTask();
-      expect(() => task.validate()).toThrow("DeleteTask: 'paths' is required");
+      expect(() => task.validate()).toThrow("DeleteTask: 'paths' or 'patterns' is required");
     });
 
     test("deletes a single file", async () => {


### PR DESCRIPTION
Enhanced DeleteTask with pattern matching capabilities similar to Ant's fileset delete:
- Added patterns() static method for glob pattern-based deletion
- Added baseDir() to set the working directory for patterns
- Added includeDirs() to control deletion of matched directories
- Maintains backward compatibility with existing paths() API
- Defaults to file-only deletion (nodir: true) unless includeDirs(true)

Example usage:
  DeleteTask.patterns("**/*.tmp", "**/*.bak") .baseDir("build") .execute();

Tests verify:
- Single and multiple pattern matching
- Directory preservation vs deletion
- Nested directory handling
- Backward compatibility with paths()