### PR TITLE
Create FileSet abstraction for reusable file collections

### DIFF
--- a/packages/file-tasks/src/FileSet.test.ts
+++ b/packages/file-tasks/src/FileSet.test.ts
@@ -1,0 +1,312 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { FileSet } from "./FileSet.ts";
+import { CopyTask } from "./CopyTask.ts";
+import { mkdir, writeFile, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { existsSync } from "fs";
+
+describe("FileSet", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `worklift-fileset-test-${Date.now()}`);
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe("Basic functionality", () => {
+    test("creates FileSet with dir method", () => {
+      const fileSet = FileSet.dir("lib");
+      expect(fileSet).toBeInstanceOf(FileSet);
+      expect(fileSet.getBaseDir()).toBe("lib");
+    });
+
+    test("supports method chaining", () => {
+      const fileSet = FileSet.dir("lib")
+        .include("**/*.jar")
+        .exclude("**/test/**");
+      expect(fileSet).toBeInstanceOf(FileSet);
+    });
+
+    test("resolves included files", async () => {
+      const libDir = join(testDir, "lib");
+      await mkdir(libDir, { recursive: true });
+      await writeFile(join(libDir, "a.jar"), "");
+      await writeFile(join(libDir, "b.jar"), "");
+      await writeFile(join(libDir, "c.txt"), "");
+
+      const fileSet = FileSet.dir(libDir).include("**/*.jar");
+
+      const files = await fileSet.resolve();
+      expect(files.length).toBe(2);
+      expect(files.some(f => f.endsWith("a.jar"))).toBe(true);
+      expect(files.some(f => f.endsWith("b.jar"))).toBe(true);
+      expect(files.some(f => f.endsWith("c.txt"))).toBe(false);
+    });
+
+    test("excludes patterns", async () => {
+      const libDir = join(testDir, "lib");
+      await mkdir(join(libDir, "test"), { recursive: true });
+      await writeFile(join(libDir, "prod.jar"), "");
+      await writeFile(join(libDir, "test", "test.jar"), "");
+
+      const fileSet = FileSet.dir(libDir)
+        .include("**/*.jar")
+        .exclude("**/test/**");
+
+      const files = await fileSet.resolve();
+      expect(files.length).toBe(1);
+      expect(files[0]).toContain("prod.jar");
+      expect(files.some(f => f.includes("test.jar"))).toBe(false);
+    });
+
+    test("returns all files when no include pattern specified", async () => {
+      const srcDir = join(testDir, "src");
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, "file1.txt"), "");
+      await writeFile(join(srcDir, "file2.js"), "");
+
+      const fileSet = FileSet.dir(srcDir);
+      const files = await fileSet.resolve();
+
+      expect(files.length).toBe(2);
+      expect(files.some(f => f.endsWith("file1.txt"))).toBe(true);
+      expect(files.some(f => f.endsWith("file2.js"))).toBe(true);
+    });
+
+    test("removes duplicates from resolved files", async () => {
+      const srcDir = join(testDir, "src");
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, "file.txt"), "");
+
+      const fileSet = FileSet.dir(srcDir)
+        .include("**/*.txt")
+        .include("file.txt");
+
+      const files = await fileSet.resolve();
+      expect(files.length).toBe(1);
+    });
+  });
+
+  describe("matching method", () => {
+    test("creates new FileSet with additional pattern", async () => {
+      const srcDir = join(testDir, "src");
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, "file.txt"), "");
+      await writeFile(join(srcDir, "temp.tmp"), "");
+
+      const baseFileSet = FileSet.dir(srcDir).include("**/*.txt");
+      const matchedFileSet = baseFileSet.matching("**/*.tmp");
+
+      const baseFiles = await baseFileSet.resolve();
+      const matchedFiles = await matchedFileSet.resolve();
+
+      expect(baseFiles.length).toBe(1);
+      expect(baseFiles[0]).toContain("file.txt");
+      expect(matchedFiles.length).toBe(2);
+      expect(matchedFiles.some(f => f.endsWith("file.txt"))).toBe(true);
+      expect(matchedFiles.some(f => f.endsWith("temp.tmp"))).toBe(true);
+    });
+
+    test("does not modify original FileSet", async () => {
+      const srcDir = join(testDir, "src");
+      await mkdir(srcDir, { recursive: true });
+
+      const original = FileSet.dir(srcDir).include("**/*.txt");
+      const matched = original.matching("**/*.tmp");
+
+      expect(original.getIncludePatterns()).toEqual(["**/*.txt"]);
+      expect(matched.getIncludePatterns()).toEqual(["**/*.txt", "**/*.tmp"]);
+    });
+  });
+
+  describe("union method", () => {
+    test("combines multiple file sets", async () => {
+      const dir1 = join(testDir, "dir1");
+      const dir2 = join(testDir, "dir2");
+      await mkdir(dir1, { recursive: true });
+      await mkdir(dir2, { recursive: true });
+      await writeFile(join(dir1, "file1.jar"), "");
+      await writeFile(join(dir1, "file2.txt"), "");
+
+      const fileSet1 = FileSet.dir(dir1).include("**/*.jar");
+      const fileSet2 = FileSet.dir(dir1).include("**/*.txt");
+
+      const combined = FileSet.union(fileSet1, fileSet2);
+      const files = await combined.resolve();
+
+      expect(files.length).toBe(2);
+      expect(files.some(f => f.endsWith("file1.jar"))).toBe(true);
+      expect(files.some(f => f.endsWith("file2.txt"))).toBe(true);
+    });
+
+    test("combines exclude patterns", async () => {
+      const srcDir = join(testDir, "src");
+      await mkdir(join(srcDir, "test"), { recursive: true });
+      await mkdir(join(srcDir, "prod"), { recursive: true });
+      await writeFile(join(srcDir, "test", "test.jar"), "");
+      await writeFile(join(srcDir, "prod", "prod.jar"), "");
+
+      const fileSet1 = FileSet.dir(srcDir)
+        .include("**/*.jar")
+        .exclude("**/test/**");
+      const fileSet2 = FileSet.dir(srcDir)
+        .include("**/*.jar")
+        .exclude("**/prod/**");
+
+      const combined = FileSet.union(fileSet1, fileSet2);
+      const files = await combined.resolve();
+
+      // Both test and prod should be excluded
+      expect(files.length).toBe(0);
+    });
+
+    test("handles empty union", () => {
+      const combined = FileSet.union();
+      expect(combined).toBeInstanceOf(FileSet);
+      expect(combined.getBaseDir()).toBe(".");
+    });
+  });
+
+  describe("Integration with CopyTask", () => {
+    test("works with CopyTask", async () => {
+      const srcDir = join(testDir, "src");
+      const destDir = join(testDir, "dest");
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, "file.txt"), "content");
+
+      const fileSet = FileSet.dir(srcDir).include("**/*.txt");
+
+      await CopyTask.files(fileSet).to(destDir).execute();
+
+      expect(existsSync(join(destDir, "file.txt"))).toBe(true);
+    });
+
+    test("preserves directory structure", async () => {
+      const srcDir = join(testDir, "src");
+      const destDir = join(testDir, "dest");
+      await mkdir(join(srcDir, "subdir"), { recursive: true });
+      await writeFile(join(srcDir, "file1.txt"), "content1");
+      await writeFile(join(srcDir, "subdir", "file2.txt"), "content2");
+
+      const fileSet = FileSet.dir(srcDir).include("**/*.txt");
+
+      await CopyTask.files(fileSet).to(destDir).execute();
+
+      expect(existsSync(join(destDir, "file1.txt"))).toBe(true);
+      expect(existsSync(join(destDir, "subdir", "file2.txt"))).toBe(true);
+    });
+
+    test("copies only included files", async () => {
+      const srcDir = join(testDir, "src");
+      const destDir = join(testDir, "dest");
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, "include.txt"), "content");
+      await writeFile(join(srcDir, "exclude.log"), "content");
+
+      const fileSet = FileSet.dir(srcDir).include("**/*.txt");
+
+      await CopyTask.files(fileSet).to(destDir).execute();
+
+      expect(existsSync(join(destDir, "include.txt"))).toBe(true);
+      expect(existsSync(join(destDir, "exclude.log"))).toBe(false);
+    });
+
+    test("respects exclude patterns", async () => {
+      const srcDir = join(testDir, "src");
+      const destDir = join(testDir, "dest");
+      await mkdir(join(srcDir, "test"), { recursive: true });
+      await writeFile(join(srcDir, "prod.txt"), "content");
+      await writeFile(join(srcDir, "test", "test.txt"), "content");
+
+      const fileSet = FileSet.dir(srcDir)
+        .include("**/*.txt")
+        .exclude("**/test/**");
+
+      await CopyTask.files(fileSet).to(destDir).execute();
+
+      expect(existsSync(join(destDir, "prod.txt"))).toBe(true);
+      expect(existsSync(join(destDir, "test", "test.txt"))).toBe(false);
+    });
+
+    test("can be reused across multiple tasks", async () => {
+      const srcDir = join(testDir, "src");
+      const dest1 = join(testDir, "dest1");
+      const dest2 = join(testDir, "dest2");
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, "file.txt"), "content");
+
+      const fileSet = FileSet.dir(srcDir).include("**/*.txt");
+
+      await CopyTask.files(fileSet).to(dest1).execute();
+      await CopyTask.files(fileSet).to(dest2).execute();
+
+      expect(existsSync(join(dest1, "file.txt"))).toBe(true);
+      expect(existsSync(join(dest2, "file.txt"))).toBe(true);
+    });
+  });
+
+  describe("Lazy evaluation", () => {
+    test("does not resolve files until needed", () => {
+      const fileSet = FileSet.dir("nonexistent")
+        .include("**/*.jar")
+        .exclude("**/test/**");
+
+      // Should not throw because files aren't resolved yet
+      expect(fileSet).toBeInstanceOf(FileSet);
+    });
+
+    test("resolves files when resolve() is called", async () => {
+      const srcDir = join(testDir, "src");
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, "file.txt"), "");
+
+      const fileSet = FileSet.dir(srcDir).include("**/*.txt");
+
+      // Before resolve
+      const filesBefore = fileSet.getIncludePatterns();
+      expect(filesBefore).toEqual(["**/*.txt"]);
+
+      // After resolve
+      const files = await fileSet.resolve();
+      expect(files.length).toBe(1);
+    });
+  });
+
+  describe("Getter methods", () => {
+    test("getBaseDir returns base directory", () => {
+      const fileSet = FileSet.dir("/path/to/lib");
+      expect(fileSet.getBaseDir()).toBe("/path/to/lib");
+    });
+
+    test("getIncludePatterns returns include patterns", () => {
+      const fileSet = FileSet.dir("lib")
+        .include("**/*.jar")
+        .include("**/*.zip");
+      expect(fileSet.getIncludePatterns()).toEqual(["**/*.jar", "**/*.zip"]);
+    });
+
+    test("getExcludePatterns returns exclude patterns", () => {
+      const fileSet = FileSet.dir("lib")
+        .exclude("**/test/**")
+        .exclude("**/debug/**");
+      expect(fileSet.getExcludePatterns()).toEqual(["**/test/**", "**/debug/**"]);
+    });
+
+    test("getter methods return copies, not references", () => {
+      const fileSet = FileSet.dir("lib").include("**/*.jar");
+      const patterns1 = fileSet.getIncludePatterns();
+      patterns1.push("**/*.zip");
+      const patterns2 = fileSet.getIncludePatterns();
+      expect(patterns2).toEqual(["**/*.jar"]);
+    });
+  });
+});

--- a/packages/file-tasks/src/FileSet.ts
+++ b/packages/file-tasks/src/FileSet.ts
@@ -1,0 +1,161 @@
+import { glob } from "glob";
+import { join, relative } from "path";
+import { minimatch } from "minimatch";
+
+/**
+ * FileSet represents a reusable collection of files with include/exclude patterns.
+ * Similar to Ant's fileset element, it allows defining file collections that can be
+ * reused across multiple tasks.
+ *
+ * Example:
+ * ```
+ * const runtimeLibs = FileSet.dir("lib")
+ *   .include("** /*.jar")
+ *   .exclude("** /test/** ");
+ *
+ * await CopyTask.files(runtimeLibs).to("build/libs");
+ * ```
+ */
+export class FileSet {
+  private baseDir: string;
+  private includePatterns: string[] = [];
+  private excludePatterns: string[] = [];
+
+  private constructor(dir: string) {
+    this.baseDir = dir;
+  }
+
+  /**
+   * Creates a new FileSet with the specified base directory.
+   *
+   * @param dir The base directory for the file set
+   * @returns A new FileSet instance
+   */
+  static dir(dir: string): FileSet {
+    return new FileSet(dir);
+  }
+
+  /**
+   * Combines multiple file sets into one.
+   * The base directory of the first file set is used as the base for the combined set.
+   *
+   * @param fileSets The file sets to combine
+   * @returns A new FileSet containing all patterns from the input file sets
+   */
+  static union(...fileSets: FileSet[]): FileSet {
+    if (fileSets.length === 0) {
+      return new FileSet(".");
+    }
+
+    const combined = new FileSet(fileSets[0].baseDir);
+    for (const fs of fileSets) {
+      combined.includePatterns.push(...fs.includePatterns);
+      combined.excludePatterns.push(...fs.excludePatterns);
+    }
+    return combined;
+  }
+
+  /**
+   * Adds include patterns to this file set.
+   * Files must match at least one include pattern to be included.
+   *
+   * @param patterns Glob patterns to include
+   * @returns This FileSet instance for method chaining
+   */
+  include(...patterns: string[]): this {
+    this.includePatterns.push(...patterns);
+    return this;
+  }
+
+  /**
+   * Adds exclude patterns to this file set.
+   * Files matching any exclude pattern will be excluded even if they match an include pattern.
+   *
+   * @param patterns Glob patterns to exclude
+   * @returns This FileSet instance for method chaining
+   */
+  exclude(...patterns: string[]): this {
+    this.excludePatterns.push(...patterns);
+    return this;
+  }
+
+  /**
+   * Creates a new FileSet with an additional include pattern.
+   * This does not modify the original FileSet.
+   *
+   * @param pattern Additional pattern to match
+   * @returns A new FileSet with the additional pattern
+   */
+  matching(pattern: string): FileSet {
+    const clone = new FileSet(this.baseDir);
+    clone.includePatterns = [...this.includePatterns, pattern];
+    clone.excludePatterns = [...this.excludePatterns];
+    return clone;
+  }
+
+  /**
+   * Resolves the file set to a list of absolute file paths.
+   * This is where the lazy evaluation happens - files are only globbed when needed.
+   *
+   * @returns A promise that resolves to an array of absolute file paths
+   */
+  async resolve(): Promise<string[]> {
+    const allFiles: string[] = [];
+
+    // If no include patterns specified, include everything
+    const patterns = this.includePatterns.length > 0
+      ? this.includePatterns
+      : ["**/*"];
+
+    // Resolve all include patterns
+    for (const pattern of patterns) {
+      const matches = await glob(pattern, {
+        cwd: this.baseDir,
+        nodir: true,
+        absolute: true,
+        dot: true,
+      });
+      allFiles.push(...matches);
+    }
+
+    // Filter out excluded files
+    const filtered = allFiles.filter(file => {
+      const relativePath = relative(this.baseDir, file);
+      return !this.excludePatterns.some(pattern =>
+        minimatch(relativePath, pattern)
+      );
+    });
+
+    // Remove duplicates
+    return [...new Set(filtered)];
+  }
+
+  /**
+   * Gets the base directory of this file set.
+   *
+   * @returns The base directory path
+   */
+  getBaseDir(): string {
+    return this.baseDir;
+  }
+
+  /**
+   * Gets the include patterns for this file set.
+   * Used internally by tasks.
+   *
+   * @returns Array of include patterns
+   */
+  getIncludePatterns(): string[] {
+    return [...this.includePatterns];
+  }
+
+  /**
+   * Gets the exclude patterns for this file set.
+   * Used internally by tasks.
+   *
+   * @returns Array of exclude patterns
+   */
+  getExcludePatterns(): string[] {
+    return [...this.excludePatterns];
+  }
+}

--- a/packages/file-tasks/src/file-tasks.test.ts
+++ b/packages/file-tasks/src/file-tasks.test.ts
@@ -33,7 +33,7 @@ describe("File Tasks", () => {
 
     test("validates from parameter is required", () => {
       const task = new CopyTask();
-      expect(() => task.validate()).toThrow("CopyTask: 'from' is required");
+      expect(() => task.validate()).toThrow("CopyTask: 'from' or 'files' is required");
     });
 
     test("validates to parameter is required", () => {

--- a/packages/file-tasks/src/index.ts
+++ b/packages/file-tasks/src/index.ts
@@ -10,3 +10,4 @@ export { CreateFileTask } from "./CreateFileTask.ts";
 export { ZipTask } from "./ZipTask.ts";
 export { UnzipTask } from "./UnzipTask.ts";
 export { ExecTask } from "./ExecTask.ts";
+export { FileSet } from "./FileSet.ts";


### PR DESCRIPTION
Implements a new FileSet class that allows defining reusable collections of files with include/exclude patterns, similar to Ant's <fileset>.

Key features:
- Lazy evaluation: files are only globbed when needed via resolve()
- Fluent API: include(), exclude(), and matching() for pattern chaining
- Union support: combine multiple file sets
- Integration with CopyTask via new files() method
- Preserves directory structure during copy operations

Changes:
- Add FileSet class with include/exclude pattern support
- Update CopyTask to accept FileSet via static files() method
- Add comprehensive test suite with 22 test cases
- Export FileSet from file-tasks package index
- Update validation message to reflect new files() option

All tests passing (82 total).