### PR TITLE
Implement file tasks with FileSet abstraction

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -1,13 +1,23 @@
 /**
  * Example build script demonstrating Worklift usage with class-based tasks API
+ *
+ * This example shows:
+ * - Project and target organization
+ * - Task dependencies
+ * - FileSet usage for advanced file selection
+ * - Common build operations
  */
 
 import { project } from "worklift";
-import { CopyTask, DeleteTask, MkdirTask, ExecTask } from "worklift";
+import { FileSet, CopyTask, DeleteTask, MkdirTask, ExecTask } from "worklift";
 import { JavacTask, JarTask, JavaTask } from "worklift";
 
 // Define a project with multiple targets using the new declarative API
 const app = project("app");
+
+// Define reusable FileSets for complex file operations
+const documentationFiles = FileSet.dir(".")
+  .include("README.md", "LICENSE", "CHANGELOG.md");
 
 // Clean target - removes build artifacts
 const clean = app.target("clean").tasks([
@@ -40,11 +50,12 @@ const packageTarget = app.target("package")
       .mainClass("com.example.Main"),
   ]);
 
-// Build target - full build process
+// Build target - full build process with FileSet example
 const build = app.target("build")
   .dependsOn(packageTarget)
   .tasks([
-    CopyTask.from("README.md").to("dist/"),
+    // Copy documentation files using FileSet
+    CopyTask.files(documentationFiles).to("dist/"),
     // Note: Multiple copy tasks can run in parallel if their inputs/outputs don't overlap
   ]);
 

--- a/examples/fileset-example.ts
+++ b/examples/fileset-example.ts
@@ -1,0 +1,245 @@
+/**
+ * FileSet Example - Advanced file selection patterns
+ *
+ * This example demonstrates how to use FileSet for complex file operations.
+ * FileSet provides a reusable, composable way to define file collections with
+ * include/exclude patterns, similar to Ant's fileset element.
+ */
+
+import { project } from "worklift";
+import { FileSet, CopyTask, ZipTask, DeleteTask, MoveTask } from "worklift";
+
+const app = project("fileset-demo");
+
+// ============================================================================
+// Define Reusable FileSets
+// ============================================================================
+
+// Source files (TypeScript only, excluding tests)
+const sourceFiles = FileSet.dir("src")
+  .include("**/*.ts")
+  .exclude("**/*.test.ts", "**/__tests__/**");
+
+// Test files
+const testFiles = FileSet.dir("src")
+  .include("**/*.test.ts", "**/__tests__/**/*.ts");
+
+// Configuration files
+const configFiles = FileSet.dir("config")
+  .include("**/*.json", "**/*.xml")
+  .exclude("**/*-local.*", "**/dev/**");
+
+// Static assets
+const staticAssets = FileSet.dir("assets")
+  .include("**/*.png", "**/*.jpg", "**/*.svg", "**/*.css")
+  .exclude("**/raw/**", "**/*.psd");  // Exclude source files
+
+// Documentation from multiple locations
+const documentation = FileSet.union(
+  FileSet.dir("docs").include("**/*.md"),
+  FileSet.dir(".").include("README.md", "LICENSE", "CHANGELOG.md")
+);
+
+// ============================================================================
+// Example 1: Basic Copy with FileSet
+// ============================================================================
+
+const copySourceFiles = app.target("copy-sources").tasks([
+  CopyTask.files(sourceFiles).to("build/src"),
+  CopyTask.files(configFiles).to("build/config"),
+]);
+
+// ============================================================================
+// Example 2: Copy with Rename (e.g., TypeScript to JavaScript)
+// ============================================================================
+
+const compileAndCopy = app.target("compile").tasks([
+  CopyTask.files(sourceFiles)
+    .to("dist/compiled")
+    .rename(/\.ts$/, ".js"),  // Rename .ts to .js
+]);
+
+// ============================================================================
+// Example 3: Flatten Directory Structure
+// ============================================================================
+
+const flattenAssets = app.target("flatten").tasks([
+  // Copy all assets to a single flat directory
+  CopyTask.files(staticAssets)
+    .to("dist/assets")
+    .flatten(true),
+]);
+
+// ============================================================================
+// Example 4: Create Archives
+// ============================================================================
+
+const createArchives = app.target("archive").tasks([
+  // Create source code archive
+  ZipTask.files(sourceFiles).to("dist/sources.zip"),
+
+  // Create documentation archive
+  ZipTask.files(documentation).to("dist/docs.zip"),
+
+  // Create distribution archive with multiple FileSets
+  CopyTask.files(sourceFiles).to("temp/dist/src"),
+  CopyTask.files(configFiles).to("temp/dist/config"),
+  CopyTask.files(staticAssets).to("temp/dist/assets"),
+  ZipTask.from("temp/dist").to("dist/release.zip"),
+  DeleteTask.paths("temp"),
+]);
+
+// ============================================================================
+// Example 5: Move Files with FileSet
+// ============================================================================
+
+const organizeFiles = app.target("organize").tasks([
+  // Move test files to a separate directory
+  MoveTask.files(testFiles)
+    .to("tests")
+    .flatten(false),  // Preserve directory structure
+]);
+
+// ============================================================================
+// Example 6: Clean Temporary Files
+// ============================================================================
+
+const cleanTemp = app.target("clean-temp").tasks([
+  // Delete all temporary files using FileSet
+  DeleteTask.files(
+    FileSet.dir("build")
+      .include("**/*.tmp", "**/*.log", "**/.DS_Store")
+  ),
+
+  // Clean build artifacts
+  DeleteTask.files(
+    FileSet.dir(".")
+      .include("**/node_modules/**/.cache/**", "**/dist/**/*.map")
+  ),
+]);
+
+// ============================================================================
+// Example 7: Production Build Pipeline
+// ============================================================================
+
+const productionBuild = app.target("production")
+  .dependsOn(cleanTemp)
+  .tasks([
+    // Copy production sources (with rename)
+    CopyTask.files(sourceFiles)
+      .to("dist/app")
+      .rename(/\.ts$/, ".js"),
+
+    // Copy production config only
+    CopyTask.files(
+      FileSet.dir("config")
+        .include("**/*.json")
+        .exclude("**/*-dev.*", "**/*-test.*")
+    ).to("dist/config"),
+
+    // Optimize and copy assets
+    CopyTask.files(staticAssets)
+      .to("dist/assets"),
+
+    // Create release package
+    ZipTask.from("dist").to("releases/app-v1.0.0.zip"),
+  ]);
+
+// ============================================================================
+// Example 8: Selective Copy with Multiple Patterns
+// ============================================================================
+
+const selectiveCopy = app.target("selective").tasks([
+  // Copy only specific file types, excluding certain directories
+  CopyTask.files(
+    FileSet.dir("src")
+      .include("**/*.ts", "**/*.tsx", "**/*.css")
+      .exclude(
+        "**/node_modules/**",
+        "**/*.test.*",
+        "**/coverage/**",
+        "**/__mocks__/**"
+      )
+  ).to("dist/app"),
+]);
+
+// ============================================================================
+// Example 9: Combining FileSets from Different Sources
+// ============================================================================
+
+const combineMultipleSources = app.target("combine").tasks([
+  // Create a combined archive from multiple sources
+  CopyTask.files(
+    FileSet.union(
+      FileSet.dir("frontend/src").include("**/*.ts", "**/*.tsx"),
+      FileSet.dir("backend/src").include("**/*.ts"),
+      FileSet.dir("shared/lib").include("**/*.ts")
+    )
+  )
+    .to("dist/all-sources")
+    .rename(/\.tsx?$/, ".js"),
+]);
+
+// ============================================================================
+// Example 10: Complex Real-World Scenario
+// ============================================================================
+
+const deployWebApp = app.target("deploy-webapp").tasks([
+  // Step 1: Copy compiled JavaScript
+  CopyTask.files(
+    FileSet.dir("src")
+      .include("**/*.ts", "**/*.tsx")
+      .exclude("**/*.test.*", "**/__tests__/**")
+  )
+    .to("deploy/app")
+    .rename(/\.tsx?$/, ".js"),
+
+  // Step 2: Copy optimized assets
+  CopyTask.files(
+    FileSet.dir("public")
+      .include("**/*.png", "**/*.jpg", "**/*.svg", "**/*.webp")
+      .exclude("**/original/**", "**/*.psd")
+  )
+    .to("deploy/assets")
+    .flatten(true),
+
+  // Step 3: Copy production config
+  CopyTask.files(
+    FileSet.dir("config")
+      .include("**/*.json", "**/*.env.production")
+      .exclude("**/*.dev.*", "**/*.local.*")
+  ).to("deploy/config"),
+
+  // Step 4: Copy HTML templates
+  CopyTask.files(
+    FileSet.dir("templates")
+      .include("**/*.html")
+  ).to("deploy/templates"),
+
+  // Step 5: Create deployment archive
+  ZipTask.from("deploy").to("releases/webapp-deploy.zip"),
+
+  // Step 6: Cleanup temporary deploy directory
+  DeleteTask.paths("deploy"),
+]);
+
+// ============================================================================
+// Run Example
+// ============================================================================
+
+console.log("=== FileSet Example ===\n");
+console.log("This example demonstrates various FileSet usage patterns.\n");
+console.log("Available targets:");
+console.log("  - copy-sources: Copy source files");
+console.log("  - compile: Copy with rename");
+console.log("  - flatten: Flatten directory structure");
+console.log("  - archive: Create archives");
+console.log("  - organize: Move files");
+console.log("  - clean-temp: Clean temporary files");
+console.log("  - production: Full production build");
+console.log("  - selective: Selective file copying");
+console.log("  - combine: Combine multiple sources");
+console.log("  - deploy-webapp: Real-world deployment\n");
+
+// You can execute any target, for example:
+// await productionBuild.execute();

--- a/packages/file-tasks/README.md
+++ b/packages/file-tasks/README.md
@@ -1,0 +1,341 @@
+# @worklift/file-tasks
+
+File and OS operation tasks for the Worklift build tool, featuring **FileSet** for advanced file selection.
+
+## Installation
+
+```bash
+bun install @worklift/file-tasks
+```
+
+## FileSet
+
+FileSet provides a reusable, declarative way to define file collections with include/exclude patterns. It's lazy-evaluated, meaning files are only resolved when needed.
+
+### Features
+
+- **Include/Exclude Patterns**: Use glob patterns to precisely select files
+- **Reusable**: Define once, use across multiple tasks
+- **Composable**: Combine multiple FileSets with `union()`
+- **Lazy Evaluation**: Files are resolved only when tasks execute
+- **Type-Safe**: Full TypeScript support
+
+### Basic Usage
+
+```typescript
+import { FileSet } from "@worklift/file-tasks";
+
+// Create a FileSet
+const sources = FileSet.dir("src")
+  .include("**/*.ts")
+  .exclude("**/*.test.ts");
+
+// Use with tasks
+CopyTask.files(sources).to("build");
+```
+
+### API
+
+#### `FileSet.dir(directory: string)`
+Creates a new FileSet with the specified base directory.
+
+```typescript
+const files = FileSet.dir("src");
+```
+
+#### `.include(...patterns: string[])`
+Adds include patterns. Files must match at least one include pattern.
+
+```typescript
+const sources = FileSet.dir("src")
+  .include("**/*.ts", "**/*.tsx");
+```
+
+#### `.exclude(...patterns: string[])`
+Adds exclude patterns. Files matching any exclude pattern are excluded even if they match an include pattern.
+
+```typescript
+const sources = FileSet.dir("src")
+  .include("**/*.ts")
+  .exclude("**/*.test.ts", "**/node_modules/**");
+```
+
+#### `.matching(pattern: string)`
+Creates a new FileSet with an additional include pattern (non-mutating).
+
+```typescript
+const allFiles = FileSet.dir("src").include("**/*");
+const tsFiles = allFiles.matching("**/*.ts");
+// Original 'allFiles' is unchanged
+```
+
+#### `FileSet.union(...fileSets: FileSet[])`
+Combines multiple FileSets into one.
+
+```typescript
+const allSources = FileSet.union(
+  FileSet.dir("src").include("**/*.ts"),
+  FileSet.dir("lib").include("**/*.ts")
+);
+```
+
+#### `.resolve(): Promise<string[]>`
+Resolves the FileSet to an array of absolute file paths. This is typically called internally by tasks.
+
+```typescript
+const files = await sourceFiles.resolve();
+console.log(files); // ['/abs/path/to/src/file1.ts', ...]
+```
+
+## Tasks
+
+All file tasks support both simple path-based operations and FileSet-based operations.
+
+### CopyTask
+
+Copy files or directories with support for renaming, flattening, and filtering.
+
+#### API Styles
+
+**Simple path-based:**
+```typescript
+CopyTask.from("src").to("dest")
+```
+
+**FileSet-based:**
+```typescript
+CopyTask.files(fileSet).to("dest")
+```
+
+#### Methods
+
+- `.from(path: string)` - Source path or glob pattern
+- `.files(fileSet: FileSet)` - Use a FileSet as source
+- `.to(path: string)` - Destination path
+- `.recursive(value: boolean)` - Copy recursively (default: true)
+- `.force(value: boolean)` - Overwrite existing files (default: true)
+- `.flatten(value: boolean)` - Flatten directory structure (default: false)
+- `.rename(pattern: RegExp, replacement: string)` - Rename files during copy
+
+#### Examples
+
+```typescript
+// Simple copy
+CopyTask.from("src").to("build");
+
+// Copy with FileSet filtering
+const sources = FileSet.dir("src")
+  .include("**/*.ts")
+  .exclude("**/*.test.ts");
+CopyTask.files(sources).to("build");
+
+// Copy and rename file extensions
+CopyTask.from("src/**/*.ts")
+  .to("dist")
+  .rename(/\.ts$/, ".js");
+
+// Copy with FileSet and flatten
+CopyTask.files(sources)
+  .to("dist")
+  .flatten(true);
+
+// Copy JAR files and strip version numbers
+CopyTask.from("lib/*.jar")
+  .to("dist/lib")
+  .rename(/^(.*)-[\d.]*\.jar$/, "$1.jar");
+```
+
+### MoveTask
+
+Move or rename files and directories.
+
+#### API Styles
+
+**Simple path-based:**
+```typescript
+MoveTask.from("old").to("new")
+```
+
+**FileSet-based:**
+```typescript
+MoveTask.files(fileSet).to("dest")
+```
+
+#### Methods
+
+- `.from(path: string)` - Source path
+- `.files(fileSet: FileSet)` - Use a FileSet as source
+- `.to(path: string)` - Destination path
+- `.flatten(value: boolean)` - Flatten directory structure (default: false)
+
+#### Examples
+
+```typescript
+// Simple move
+MoveTask.from("temp/file.txt").to("archive/file.txt");
+
+// Move multiple files with FileSet
+const tempFiles = FileSet.dir("temp")
+  .include("**/*.tmp");
+MoveTask.files(tempFiles).to("archive");
+
+// Move and flatten
+MoveTask.files(tempFiles)
+  .to("archive")
+  .flatten(true);
+```
+
+### DeleteTask
+
+Delete files or directories with support for patterns and FileSets.
+
+#### API Styles
+
+**Explicit paths:**
+```typescript
+DeleteTask.paths("file1", "file2")
+```
+
+**Glob patterns:**
+```typescript
+DeleteTask.patterns("**/*.tmp")
+```
+
+**FileSet-based:**
+```typescript
+DeleteTask.files(fileSet)
+```
+
+#### Methods
+
+- `.paths(...paths: string[])` - Delete specific paths
+- `.patterns(...patterns: string[])` - Delete files matching patterns
+- `.files(fileSet: FileSet)` - Delete files from a FileSet
+- `.baseDir(dir: string)` - Base directory for pattern matching
+- `.recursive(value: boolean)` - Delete recursively (default: true)
+- `.includeDirs(value: boolean)` - Include directories in pattern matching (default: false)
+
+#### Examples
+
+```typescript
+// Delete specific paths
+DeleteTask.paths("build", "dist");
+
+// Delete using patterns
+DeleteTask.patterns("**/*.tmp", "**/*.log")
+  .baseDir("build");
+
+// Delete using FileSet
+const tempFiles = FileSet.dir("build")
+  .include("**/*.tmp", "**/*.log");
+DeleteTask.files(tempFiles);
+```
+
+### ZipTask
+
+Create ZIP archives.
+
+#### API Styles
+
+**Simple path-based:**
+```typescript
+ZipTask.from("src").to("archive.zip")
+```
+
+**FileSet-based:**
+```typescript
+ZipTask.files(fileSet).to("archive.zip")
+```
+
+#### Methods
+
+- `.from(path: string)` - Source directory
+- `.files(fileSet: FileSet)` - Use a FileSet as source
+- `.to(file: string)` - Destination ZIP file
+- `.recursive(value: boolean)` - Zip recursively (default: true)
+
+#### Examples
+
+```typescript
+// Simple zip
+ZipTask.from("dist").to("releases/app.zip");
+
+// Zip selected files using FileSet
+const deployFiles = FileSet.dir("dist")
+  .include("**/*.js", "**/*.json")
+  .exclude("**/*.map", "**/test/**");
+ZipTask.files(deployFiles).to("releases/app.zip");
+```
+
+### MkdirTask
+
+Create directories.
+
+```typescript
+MkdirTask.paths("build/classes", "dist", "temp");
+```
+
+### CreateFileTask
+
+Create a file with content.
+
+```typescript
+CreateFileTask.path("config.json")
+  .content('{"version": "1.0.0"}')
+  .encoding("utf-8");
+```
+
+### UnzipTask
+
+Extract ZIP archives.
+
+```typescript
+UnzipTask.file("archive.zip")
+  .to("extracted")
+  .overwrite(true);
+```
+
+### ExecTask
+
+Execute shell commands.
+
+```typescript
+ExecTask.command("npm")
+  .args(["install"])
+  .cwd("project")
+  .env({ NODE_ENV: "production" });
+```
+
+## Migration from Previous API
+
+If you were using the old `include()` and `exclude()` methods on `CopyTask`, migrate to FileSet:
+
+**Before:**
+```typescript
+CopyTask.from("src")
+  .include("**/*.ts")
+  .exclude("**/*.test.ts")
+  .to("build");
+```
+
+**After:**
+```typescript
+const sources = FileSet.dir("src")
+  .include("**/*.ts")
+  .exclude("**/*.test.ts");
+
+CopyTask.files(sources).to("build");
+```
+
+**Or use glob directly for simple cases:**
+```typescript
+CopyTask.from("src/**/*.ts").to("build");
+```
+
+## Examples
+
+See [examples/fileset-example.ts](../../examples/fileset-example.ts) for comprehensive FileSet usage patterns.
+
+## License
+
+MIT

--- a/packages/file-tasks/src/CopyTask.exclude.test.ts
+++ b/packages/file-tasks/src/CopyTask.exclude.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { CopyTask } from "./CopyTask";
+import { FileSet } from "./FileSet";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
 
-describe("CopyTask with excludes", () => {
+describe("CopyTask with FileSet excludes", () => {
   beforeEach(() => {
     mkdirSync("test-temp/src", { recursive: true });
     mkdirSync("test-temp/src/subdir");
@@ -20,10 +21,8 @@ describe("CopyTask with excludes", () => {
   });
 
   test("excludes single file", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
-      .exclude("file2.tmp")
-      .execute();
+    const fileSet = FileSet.dir("test-temp/src").exclude("file2.tmp");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(true);
     expect(existsSync("test-temp/dest/file2.tmp")).toBe(false);
@@ -31,10 +30,8 @@ describe("CopyTask with excludes", () => {
   });
 
   test("excludes with glob pattern", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
-      .exclude("**/*.tmp")
-      .execute();
+    const fileSet = FileSet.dir("test-temp/src").exclude("**/*.tmp");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(true);
     expect(existsSync("test-temp/dest/file2.tmp")).toBe(false);
@@ -43,10 +40,8 @@ describe("CopyTask with excludes", () => {
   });
 
   test("excludes multiple patterns", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
-      .exclude("**/*.tmp", "**/subdir/**")
-      .execute();
+    const fileSet = FileSet.dir("test-temp/src").exclude("**/*.tmp", "**/subdir/**");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(true);
     expect(existsSync("test-temp/dest/file2.tmp")).toBe(false);
@@ -54,11 +49,10 @@ describe("CopyTask with excludes", () => {
   });
 
   test("excludes with chained calls", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
+    const fileSet = FileSet.dir("test-temp/src")
       .exclude("**/*.tmp")
-      .exclude("**/*.bak")
-      .execute();
+      .exclude("**/*.bak");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(true);
     expect(existsSync("test-temp/dest/file2.tmp")).toBe(false);
@@ -67,19 +61,15 @@ describe("CopyTask with excludes", () => {
   });
 
   test("excludes directory with wildcard", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
-      .exclude("**/test/**")
-      .execute();
+    const fileSet = FileSet.dir("test-temp/src").exclude("**/test/**");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(true);
     expect(existsSync("test-temp/dest/test/test.txt")).toBe(false);
   });
 
   test("works without excludes (backward compatibility)", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
-      .execute();
+    await CopyTask.from("test-temp/src").to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(true);
     expect(existsSync("test-temp/dest/file2.tmp")).toBe(true);
@@ -88,10 +78,8 @@ describe("CopyTask with excludes", () => {
   });
 
   test("excludes specific file in subdirectory", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
-      .exclude("subdir/file3.txt")
-      .execute();
+    const fileSet = FileSet.dir("test-temp/src").exclude("subdir/file3.txt");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(true);
     expect(existsSync("test-temp/dest/subdir/file3.txt")).toBe(false);
@@ -99,10 +87,9 @@ describe("CopyTask with excludes", () => {
   });
 
   test("excludes with multiple wildcards", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
-      .exclude("**/*.tmp", "**/*.bak", "**/test/**")
-      .execute();
+    const fileSet = FileSet.dir("test-temp/src")
+      .exclude("**/*.tmp", "**/*.bak", "**/test/**");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(true);
     expect(existsSync("test-temp/dest/file2.tmp")).toBe(false);

--- a/packages/file-tasks/src/CopyTask.include.test.ts
+++ b/packages/file-tasks/src/CopyTask.include.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { CopyTask } from "./CopyTask";
+import { FileSet } from "./FileSet";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
 
-describe("CopyTask with includes", () => {
+describe("CopyTask with FileSet includes", () => {
   beforeEach(() => {
     mkdirSync("test-temp/src", { recursive: true });
     mkdirSync("test-temp/src/subdir");
@@ -21,10 +22,8 @@ describe("CopyTask with includes", () => {
   });
 
   test("includes only matching files", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
-      .include("**/*.ts")
-      .execute();
+    const fileSet = FileSet.dir("test-temp/src").include("**/*.ts");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(false);
     expect(existsSync("test-temp/dest/file2.ts")).toBe(true);
@@ -33,10 +32,8 @@ describe("CopyTask with includes", () => {
   });
 
   test("includes multiple patterns", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
-      .include("**/*.ts", "**/*.js")
-      .execute();
+    const fileSet = FileSet.dir("test-temp/src").include("**/*.ts", "**/*.js");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(false);
     expect(existsSync("test-temp/dest/file2.ts")).toBe(true);
@@ -46,11 +43,10 @@ describe("CopyTask with includes", () => {
   });
 
   test("includes with chained calls", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
+    const fileSet = FileSet.dir("test-temp/src")
       .include("**/*.ts")
-      .include("**/*.js")
-      .execute();
+      .include("**/*.js");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(false);
     expect(existsSync("test-temp/dest/file2.ts")).toBe(true);
@@ -59,10 +55,8 @@ describe("CopyTask with includes", () => {
   });
 
   test("includes specific files", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
-      .include("file2.ts", "subdir/file5.txt")
-      .execute();
+    const fileSet = FileSet.dir("test-temp/src").include("file2.ts", "subdir/file5.txt");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(false);
     expect(existsSync("test-temp/dest/file2.ts")).toBe(true);
@@ -72,10 +66,8 @@ describe("CopyTask with includes", () => {
   });
 
   test("includes from specific directory", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
-      .include("subdir/**")
-      .execute();
+    const fileSet = FileSet.dir("test-temp/src").include("subdir/**");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(false);
     expect(existsSync("test-temp/dest/file2.ts")).toBe(false);
@@ -84,11 +76,10 @@ describe("CopyTask with includes", () => {
   });
 
   test("combines include and exclude patterns", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
+    const fileSet = FileSet.dir("test-temp/src")
       .include("**/*.txt")
-      .exclude("**/test/**")
-      .execute();
+      .exclude("**/test/**");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(true);
     expect(existsSync("test-temp/dest/file2.ts")).toBe(false);
@@ -97,11 +88,10 @@ describe("CopyTask with includes", () => {
   });
 
   test("combines include and exclude with multiple patterns", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
+    const fileSet = FileSet.dir("test-temp/src")
       .include("**/*.ts", "**/*.js")
-      .exclude("**/subdir/**")
-      .execute();
+      .exclude("**/subdir/**");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(false);
     expect(existsSync("test-temp/dest/file2.ts")).toBe(true);
@@ -110,22 +100,20 @@ describe("CopyTask with includes", () => {
   });
 
   test("exclude takes precedence over include", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
+    const fileSet = FileSet.dir("test-temp/src")
       .include("**/*.ts")
-      .exclude("**/*.ts")
-      .execute();
+      .exclude("**/*.ts");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file2.ts")).toBe(false);
     expect(existsSync("test-temp/dest/subdir/file6.ts")).toBe(false);
   });
 
   test("works with all text files except backups", async () => {
-    await CopyTask.from("test-temp/src")
-      .to("test-temp/dest")
+    const fileSet = FileSet.dir("test-temp/src")
       .include("**/*.txt", "**/*.ts", "**/*.js")
-      .exclude("**/*.bak")
-      .execute();
+      .exclude("**/*.bak");
+    await CopyTask.files(fileSet).to("test-temp/dest").execute();
 
     expect(existsSync("test-temp/dest/file1.txt")).toBe(true);
     expect(existsSync("test-temp/dest/file2.ts")).toBe(true);

--- a/packages/file-tasks/src/DeleteTask.test.ts
+++ b/packages/file-tasks/src/DeleteTask.test.ts
@@ -113,7 +113,7 @@ describe("DeleteTask with patterns", () => {
     const task = new DeleteTask();
 
     expect(() => task.validate()).toThrow(
-      "DeleteTask: 'paths' or 'patterns' is required"
+      "DeleteTask: 'paths', 'patterns', or 'files' is required"
     );
   });
 });

--- a/packages/file-tasks/src/MoveTask.ts
+++ b/packages/file-tasks/src/MoveTask.ts
@@ -1,12 +1,17 @@
 import { Task } from "@worklift/core";
-import { rename } from "fs/promises";
+import { rename, mkdir } from "fs/promises";
+import { relative, join, dirname, basename } from "path";
+import { FileSet } from "./FileSet.ts";
 
 /**
- * Task for moving/renaming files or directories
+ * Task for moving/renaming files or directories.
+ * Use FileSet for moving multiple files.
  */
 export class MoveTask extends Task {
   private fromPath?: string;
+  private fileSet?: FileSet;
   private toPath?: string;
+  private flattenFlag = false;
 
   inputs?: string | string[];
   outputs?: string | string[];
@@ -18,15 +23,26 @@ export class MoveTask extends Task {
     return task;
   }
 
+  static files(fileSet: FileSet): MoveTask {
+    const task = new MoveTask();
+    task.fileSet = fileSet;
+    return task;
+  }
+
   to(path: string): this {
     this.toPath = path;
     this.outputs = path;
     return this;
   }
 
+  flatten(value: boolean): this {
+    this.flattenFlag = value;
+    return this;
+  }
+
   validate() {
-    if (!this.fromPath) {
-      throw new Error("MoveTask: 'from' is required");
+    if (!this.fromPath && !this.fileSet) {
+      throw new Error("MoveTask: 'from' or 'files' is required");
     }
     if (!this.toPath) {
       throw new Error("MoveTask: 'to' is required");
@@ -34,7 +50,37 @@ export class MoveTask extends Task {
   }
 
   async execute() {
-    console.log(`  ↳ Moving ${this.fromPath} to ${this.toPath}`);
-    await rename(this.fromPath!, this.toPath!);
+    if (this.fileSet) {
+      console.log(`  ↳ Moving files from FileSet to ${this.toPath}`);
+      await this.moveFromFileSet();
+    } else {
+      console.log(`  ↳ Moving ${this.fromPath} to ${this.toPath}`);
+      await rename(this.fromPath!, this.toPath!);
+    }
+  }
+
+  private async moveFromFileSet() {
+    const files = await this.fileSet!.resolve();
+    const baseDir = this.fileSet!.getBaseDir();
+
+    // Ensure destination directory exists
+    await mkdir(this.toPath!, { recursive: true });
+
+    for (const file of files) {
+      let destPath: string;
+
+      if (this.flattenFlag) {
+        // Flatten: move all files to destination root
+        const filename = basename(file);
+        destPath = join(this.toPath!, filename);
+      } else {
+        // Preserve directory structure
+        const relativePath = relative(baseDir, file);
+        destPath = join(this.toPath!, relativePath);
+        await mkdir(dirname(destPath), { recursive: true });
+      }
+
+      await rename(file, destPath);
+    }
   }
 }

--- a/packages/file-tasks/src/ZipTask.ts
+++ b/packages/file-tasks/src/ZipTask.ts
@@ -1,11 +1,15 @@
 import { Task } from "@worklift/core";
 import { spawn } from "child_process";
+import { relative, isAbsolute, resolve as resolvePath } from "path";
+import { FileSet } from "./FileSet.ts";
 
 /**
- * Task for creating ZIP archives
+ * Task for creating ZIP archives.
+ * Use FileSet for zipping specific file collections.
  */
 export class ZipTask extends Task {
   private sourcePath?: string;
+  private fileSet?: FileSet;
   private zipFile?: string;
   private recursiveFlag = true;
 
@@ -16,6 +20,12 @@ export class ZipTask extends Task {
     const task = new ZipTask();
     task.sourcePath = path;
     task.inputs = path;
+    return task;
+  }
+
+  static files(fileSet: FileSet): ZipTask {
+    const task = new ZipTask();
+    task.fileSet = fileSet;
     return task;
   }
 
@@ -31,8 +41,8 @@ export class ZipTask extends Task {
   }
 
   validate() {
-    if (!this.sourcePath) {
-      throw new Error("ZipTask: 'from' is required");
+    if (!this.sourcePath && !this.fileSet) {
+      throw new Error("ZipTask: 'from' or 'files' is required");
     }
     if (!this.zipFile) {
       throw new Error("ZipTask: 'to' is required");
@@ -42,6 +52,14 @@ export class ZipTask extends Task {
   async execute() {
     console.log(`  ↳ Creating ZIP archive: ${this.zipFile}`);
 
+    if (this.fileSet) {
+      await this.zipFromFileSet();
+    } else {
+      await this.zipFromPath();
+    }
+  }
+
+  private async zipFromPath(): Promise<void> {
     const args = ["-q"];
     if (this.recursiveFlag) {
       args.push("-r");
@@ -50,6 +68,40 @@ export class ZipTask extends Task {
 
     return new Promise<void>((resolve, reject) => {
       const proc = spawn("zip", args, {
+        stdio: "inherit",
+      });
+
+      proc.on("close", (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`zip failed with exit code ${code}`));
+        }
+      });
+
+      proc.on("error", (error) => {
+        reject(new Error(`Failed to execute zip: ${error.message}`));
+      });
+    });
+  }
+
+  private async zipFromFileSet(): Promise<void> {
+    const files = await this.fileSet!.resolve();
+    const baseDir = this.fileSet!.getBaseDir();
+
+    // Convert absolute paths to relative paths from baseDir
+    const relativePaths = files.map(file => relative(baseDir, file));
+
+    // Make zipFile path absolute if it's relative, resolving from cwd
+    const absoluteZipFile = isAbsolute(this.zipFile!)
+      ? this.zipFile!
+      : resolvePath(process.cwd(), this.zipFile!);
+
+    const args = ["-q", absoluteZipFile, ...relativePaths];
+
+    return new Promise<void>((resolve, reject) => {
+      const proc = spawn("zip", args, {
+        cwd: baseDir,  // Execute in FileSet's base directory
         stdio: "inherit",
       });
 

--- a/packages/file-tasks/src/file-tasks.test.ts
+++ b/packages/file-tasks/src/file-tasks.test.ts
@@ -225,7 +225,7 @@ describe("File Tasks", () => {
 
     test("validates paths or patterns parameter is required", () => {
       const task = new DeleteTask();
-      expect(() => task.validate()).toThrow("DeleteTask: 'paths' or 'patterns' is required");
+      expect(() => task.validate()).toThrow("DeleteTask: 'paths', 'patterns', or 'files' is required");
     });
 
     test("deletes a single file", async () => {
@@ -277,7 +277,7 @@ describe("File Tasks", () => {
 
     test("validates from parameter is required", () => {
       const task = new MoveTask();
-      expect(() => task.validate()).toThrow("MoveTask: 'from' is required");
+      expect(() => task.validate()).toThrow("MoveTask: 'from' or 'files' is required");
     });
 
     test("validates to parameter is required", () => {


### PR DESCRIPTION
Breaking Changes:
- CopyTask: Removed include() and exclude() methods. Use FileSet instead for advanced file filtering.
  - Before: CopyTask.from("src").include("**/*.ts").exclude("**/test/**").to("dest")
  - After: CopyTask.files(FileSet.dir("src").include("**/*.ts").exclude("**/test/**")).to("dest")

New Features:
- All file tasks now support FileSet via files() static method:
  - CopyTask.files(fileSet).to("dest") - supports rename() and flatten()
  - MoveTask.files(fileSet).to("dest") - supports flatten()
  - ZipTask.files(fileSet).to("archive.zip")
  - DeleteTask.files(fileSet)

API Consistency:
- Dual API pattern: from() for simple paths, files() for FileSet
- FileSet handles file selection (include/exclude patterns)
- Task operations (flatten, rename) remain on task classes
- All tasks maintain backward compatibility with from() method

Updated Tests:
- Migrated CopyTask include/exclude tests to use FileSet
- Updated validation error messages
- All 94 tests passing