### PR TITLE
Add comprehensive Java Maven project example

### DIFF
--- a/examples/java-maven-project/README.md
+++ b/examples/java-maven-project/README.md
@@ -1,0 +1,293 @@
+# Java Maven Project Example
+
+A comprehensive example demonstrating how to build multi-module Java projects using **Worklift** with Maven conventions.
+
+## What This Example Demonstrates
+
+- **Maven Directory Conventions**: `src/main/java`, `src/test/java`, `build/` structure
+- **Multi-Module Projects**: Library module (`string-utils`) and application module (`app`)
+- **Inter-Module Dependencies**: App depends on the string-utils library
+- **Maven Dependency Resolution**: Automatically fetch and use external dependencies
+- **Testing with JUnit 5**: Comprehensive test coverage for both modules
+- **JAR Packaging**: Create distributable JAR files
+- **Build Automation**: Complete build pipeline with dependency management
+
+## Project Structure
+
+```
+java-maven-project/
+├── build.ts                     # Worklift build script
+├── README.md                    # This file
+│
+├── string-utils/                # Library module
+│   ├── src/
+│   │   ├── main/java/          # Maven convention: main source code
+│   │   │   └── com/example/utils/
+│   │   │       └── StringUtils.java
+│   │   └── test/java/          # Maven convention: test code
+│   │       └── com/example/utils/
+│   │           └── StringUtilsTest.java
+│   └── build/                  # Build output (generated)
+│       ├── classes/            # Compiled classes
+│       ├── test-classes/       # Compiled test classes
+│       └── libs/               # JAR files
+│           └── string-utils.jar
+│
+└── app/                        # Application module
+    ├── src/
+    │   ├── main/java/          # Maven convention: main source code
+    │   │   └── com/example/app/
+    │   │       └── Application.java
+    │   └── test/java/          # Maven convention: test code
+    │       └── com/example/app/
+    │           └── ApplicationTest.java
+    └── build/                  # Build output (generated)
+        ├── classes/            # Compiled classes
+        ├── test-classes/       # Compiled test classes
+        └── libs/               # JAR files
+            └── app.jar
+```
+
+## Modules
+
+### string-utils (Library Module)
+
+A reusable utility library providing string manipulation functions:
+
+- `reverse(String)` - Reverses a string
+- `isPalindrome(String)` - Checks if a string is a palindrome
+- `capitalizeWords(String)` - Capitalizes first letter of each word
+- `countWords(String)` - Counts words in a string
+
+**Dependencies**: None (pure Java library)
+
+**Tests**: Comprehensive JUnit 5 test suite
+
+### app (Application Module)
+
+Demonstration application that:
+- Uses the `string-utils` library
+- Uses external Maven dependency (`org.json:json`)
+- Shows integration of library and external dependencies
+- Outputs formatted JSON results
+
+**Dependencies**:
+- `string-utils` (library module)
+- `org.json:json:20230227` (Maven Central)
+
+**Tests**: JUnit 5 tests demonstrating integration testing
+
+## Running the Example
+
+### Build and Run
+
+**Important**: Run from within the example directory:
+
+```bash
+cd examples/java-maven-project
+bun run build.ts
+```
+
+This will:
+1. Resolve Maven dependencies (JUnit 5, org.json)
+2. Build the string-utils library
+   - Clean previous build
+   - Compile sources
+   - Package as JAR
+3. Build the app module
+   - Clean previous build
+   - Resolve dependencies (org.json)
+   - Compile sources (using string-utils JAR)
+   - Run the application
+
+### Run Individual Targets
+
+You can also run specific targets by modifying `build.ts`:
+
+```typescript
+// Run only library tests
+await stringUtilsTest.execute();
+
+// Run only app tests
+await appTest.execute();
+
+// Run the application
+await appRun.execute();
+
+// Build only the library
+await stringUtilsBuild.execute();
+
+// Build only the app
+await appBuild.execute();
+```
+
+## Key Worklift Features Demonstrated
+
+### 1. Maven Dependency Resolution
+
+```typescript
+const junitClasspath = artifact("junit-classpath", z.array(z.string()));
+
+const resolveDeps = project
+  .target("resolve-deps")
+  .produces(junitClasspath)
+  .tasks([
+    MavenDepTask.resolve("org.junit.jupiter:junit-jupiter:5.9.3")
+      .into(junitClasspath),
+  ]);
+```
+
+### 2. Library Module Dependencies
+
+```typescript
+// App depends on string-utils JAR
+const appCompile = app
+  .target("compile")
+  .dependsOn(stringUtilsJar)  // Ensures library is built first
+  .tasks([
+    JavacTask.sources("app/src/main/java/**/*.java")
+      .destination("app/build/classes")
+      .classpath(
+        "string-utils/build/libs/string-utils.jar"  // Use library JAR
+      ),
+  ]);
+```
+
+### 3. Testing with JUnit 5
+
+```typescript
+const test = project
+  .target("test")
+  .tasks([
+    JavaTask.mainClass("org.junit.platform.console.ConsoleLauncher")
+      .classpath(junitClasspath, "build/classes", "build/test-classes")
+      .args([
+        "--scan-classpath",
+        "build/test-classes",
+        "--fail-if-no-tests",
+      ]),
+  ]);
+```
+
+### 4. JAR Packaging
+
+```typescript
+const jar = project
+  .target("jar")
+  .tasks([
+    JarTask.from("build/classes")
+      .to("build/libs/app.jar")
+      .mainClass("com.example.app.Application"),
+  ]);
+```
+
+### 5. Multi-Module Coordination
+
+```typescript
+// Build everything in correct order
+const buildAll = app
+  .target("build-all")
+  .dependsOn(stringUtilsBuild, appBuild);
+```
+
+## Maven Conventions Used
+
+1. **Directory Structure**
+   - `src/main/java` - Production source code
+   - `src/test/java` - Test source code
+   - `build/classes` - Compiled production classes
+   - `build/test-classes` - Compiled test classes
+   - `build/libs` - Output JAR files
+
+2. **Package Naming**
+   - Reverse domain name: `com.example.utils`, `com.example.app`
+
+3. **Dependency Management**
+   - Centralized dependency resolution
+   - Artifact coordinates: `groupId:artifactId:version`
+
+4. **Testing**
+   - Separate test source tree
+   - JUnit 5 conventions
+
+## Differences from Maven
+
+While this example follows Maven conventions, it uses **Worklift** instead of Maven:
+
+| Aspect | Maven | Worklift |
+|--------|-------|----------|
+| Configuration | XML (`pom.xml`) | TypeScript (type-safe!) |
+| Build Script | Declarative | Programmatic + Declarative |
+| Plugin System | XML-based | Native TypeScript/JavaScript |
+| IDE Support | Specialized Maven plugins | Any TypeScript IDE |
+| Learning Curve | Maven-specific | Standard TypeScript/JavaScript |
+| Extensibility | Write Java plugins | Write TypeScript functions |
+
+## Expected Output
+
+```
+=== Java Maven Project Example with Worklift ===
+
+This demonstrates:
+  • Multi-module Maven project structure
+  • Maven directory conventions (src/main/java, src/test/java)
+  • Library modules (string-utils)
+  • Application modules (app)
+  • Inter-module dependencies
+  • Maven dependency resolution (JUnit 5, org.json)
+  • Testing with JUnit 5
+  • JAR packaging
+
+Building all modules...
+
+[string-utils] Compiling...
+[string-utils] Running tests...
+[string-utils] Packaging JAR...
+[app] Resolving dependencies...
+[app] Compiling...
+[app] Running tests...
+[app] Packaging JAR...
+
+✓ Build completed successfully!
+
+--- Running the application ---
+
+=== Java Maven Project Example ===
+
+Original text: hello worklift
+Capitalized: Hello Worklift
+Reversed: tfilkrow olleh
+Word count: 2
+
+'racecar' is palindrome: true
+
+--- JSON Output (using org.json:json) ---
+{
+  "text": "hello worklift",
+  "capitalized": "Hello Worklift",
+  "reversed": "tfilkrow olleh",
+  "wordCount": 2,
+  "isPalindrome": false
+}
+
+✓ Application completed successfully!
+This demonstrates:
+  • Multi-module Maven project structure
+  • Library module dependencies
+  • External Maven dependencies (org.json)
+  • Built with Worklift!
+```
+
+## Next Steps
+
+- Modify `string-utils/src/main/java/com/example/utils/StringUtils.java` to add new utility functions
+- Add more tests in the test directories
+- Add more Maven dependencies in `build.ts`
+- Create additional modules following the same conventions
+- Explore different JUnit 5 testing features
+
+## Learn More
+
+- [Worklift Documentation](../../README.md)
+- [Maven Directory Structure](https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html)
+- [JUnit 5 User Guide](https://junit.org/junit5/docs/current/user-guide/)

--- a/examples/java-maven-project/app/src/main/java/com/example/app/Application.java
+++ b/examples/java-maven-project/app/src/main/java/com/example/app/Application.java
@@ -1,0 +1,47 @@
+package com.example.app;
+
+import com.example.utils.StringUtils;
+import org.json.JSONObject;
+
+/**
+ * Main application demonstrating:
+ * - Using the string-utils library module
+ * - Using external Maven dependencies (org.json:json)
+ * - Maven conventions for application structure
+ */
+public class Application {
+
+    public static void main(String[] args) {
+        System.out.println("=== Java Maven Project Example ===\n");
+
+        // Demonstrate using the string-utils library
+        String text = "hello worklift";
+        System.out.println("Original text: " + text);
+        System.out.println("Capitalized: " + StringUtils.capitalizeWords(text));
+        System.out.println("Reversed: " + StringUtils.reverse(text));
+        System.out.println("Word count: " + StringUtils.countWords(text));
+
+        // Test palindrome
+        String palindrome = "racecar";
+        System.out.println("\n'" + palindrome + "' is palindrome: " +
+                         StringUtils.isPalindrome(palindrome));
+
+        // Demonstrate using external Maven dependency (org.json)
+        System.out.println("\n--- JSON Output (using org.json:json) ---");
+        JSONObject json = new JSONObject();
+        json.put("text", text);
+        json.put("capitalized", StringUtils.capitalizeWords(text));
+        json.put("reversed", StringUtils.reverse(text));
+        json.put("wordCount", StringUtils.countWords(text));
+        json.put("isPalindrome", StringUtils.isPalindrome(text));
+
+        System.out.println(json.toString(2));
+
+        System.out.println("\n✓ Application completed successfully!");
+        System.out.println("This demonstrates:");
+        System.out.println("  • Multi-module Maven project structure");
+        System.out.println("  • Library module dependencies");
+        System.out.println("  • External Maven dependencies (org.json)");
+        System.out.println("  • Built with Worklift!");
+    }
+}

--- a/examples/java-maven-project/app/src/test/java/com/example/app/ApplicationTest.java
+++ b/examples/java-maven-project/app/src/test/java/com/example/app/ApplicationTest.java
@@ -1,0 +1,52 @@
+package com.example.app;
+
+import com.example.utils.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.json.JSONObject;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class demonstrating:
+ * - Testing with JUnit 5
+ * - Using library module in tests
+ * - Using Maven dependencies in tests
+ */
+public class ApplicationTest {
+
+    @Test
+    public void testStringUtilsIntegration() {
+        String text = "hello world";
+        String capitalized = StringUtils.capitalizeWords(text);
+
+        assertEquals("Hello World", capitalized);
+        assertNotNull(StringUtils.reverse(text));
+        assertTrue(StringUtils.countWords(text) > 0);
+    }
+
+    @Test
+    public void testJSONIntegration() {
+        // Test that we can use org.json in tests too
+        JSONObject json = new JSONObject();
+        json.put("message", "test");
+        json.put("count", 42);
+
+        assertEquals("test", json.getString("message"));
+        assertEquals(42, json.getInt("count"));
+        assertTrue(json.has("message"));
+    }
+
+    @Test
+    public void testCombinedFunctionality() {
+        String input = "test string";
+        String reversed = StringUtils.reverse(input);
+
+        JSONObject result = new JSONObject();
+        result.put("original", input);
+        result.put("reversed", reversed);
+        result.put("wordCount", StringUtils.countWords(input));
+
+        assertEquals(input, result.getString("original"));
+        assertEquals(reversed, result.getString("reversed"));
+        assertEquals(2, result.getInt("wordCount"));
+    }
+}

--- a/examples/java-maven-project/build.ts
+++ b/examples/java-maven-project/build.ts
@@ -1,0 +1,271 @@
+/**
+ * Multi-module Java project demonstrating Maven conventions with Worklift
+ *
+ * This example shows:
+ * 1. Maven directory conventions (src/main/java, src/test/java)
+ * 2. Multi-module project structure with library and application modules
+ * 3. Maven dependency resolution (JUnit 5, org.json)
+ * 4. Library module dependencies (app depends on string-utils)
+ * 5. Comprehensive testing with JUnit 5
+ * 6. Building, packaging, and running
+ *
+ * Structure:
+ *   string-utils/          - Reusable library module
+ *     src/main/java/       - Library source code
+ *     src/test/java/       - Library tests
+ *   app/                   - Application module
+ *     src/main/java/       - Application source code
+ *     src/test/java/       - Application tests
+ */
+
+import { project, artifact } from "@worklift/core";
+import {
+  JavacTask,
+  JavaTask,
+  JarTask,
+  MavenDepTask,
+} from "@worklift/java-tasks";
+import { DeleteTask } from "@worklift/file-tasks";
+import { z } from "zod";
+
+// ============================================================================
+// Artifacts for dependency management
+// ============================================================================
+
+// JUnit 5 dependencies for testing
+const junitClasspath = artifact("junit-classpath", z.array(z.string()));
+
+// External dependencies for the application (org.json)
+const appDependencies = artifact("app-dependencies", z.array(z.string()));
+
+// ============================================================================
+// STRING-UTILS Library Module
+// Following Maven conventions: src/main/java and src/test/java
+// ============================================================================
+
+const stringUtils = project("string-utils");
+
+// Clean build directory
+export const stringUtilsClean = stringUtils
+  .target("clean")
+  .tasks([DeleteTask.paths("string-utils/build").recursive(true)]);
+
+// Resolve JUnit 5 dependencies for testing
+export const stringUtilsResolveDeps = stringUtils
+  .target("resolve-deps")
+  .produces(junitClasspath)
+  .tasks([
+    MavenDepTask.resolve(
+      "org.junit.jupiter:junit-jupiter:5.9.3"
+    ).into(junitClasspath),
+  ]);
+
+// Compile library sources
+// Maven convention: src/main/java -> build/classes
+// Note: JavacTask creates output directory automatically
+export const stringUtilsCompile = stringUtils
+  .target("compile")
+  .dependsOn(stringUtilsClean)
+  .tasks([
+    JavacTask.sources("string-utils/src/main/java/com/example/utils/StringUtils.java")
+      .destination("string-utils/build/classes")
+      .sourceVersion("11")
+      .targetVersion("11"),
+  ]);
+
+// Compile library tests
+// Maven convention: src/test/java -> build/test-classes
+export const stringUtilsCompileTests = stringUtils
+  .target("compile-tests")
+  .dependsOn(stringUtilsCompile, stringUtilsResolveDeps)
+  .tasks([
+    JavacTask.sources("string-utils/src/test/java/com/example/utils/StringUtilsTest.java")
+      .destination("string-utils/build/test-classes")
+      .classpath(
+        junitClasspath,
+        "string-utils/build/classes"
+      )
+      .sourceVersion("11")
+      .targetVersion("11"),
+  ]);
+
+// Run library tests with JUnit 5
+export const stringUtilsTest = stringUtils
+  .target("test")
+  .dependsOn(stringUtilsCompileTests)
+  .tasks([
+    JavaTask.mainClass("org.junit.platform.console.ConsoleLauncher")
+      .classpath(
+        junitClasspath,
+        "string-utils/build/classes",
+        "string-utils/build/test-classes"
+      )
+      .args([
+        "--scan-classpath",
+        "string-utils/build/test-classes",
+        "--fail-if-no-tests",
+      ]),
+  ]);
+
+// Package library as JAR
+// Maven convention: build/libs/string-utils.jar
+export const stringUtilsJar = stringUtils
+  .target("jar")
+  .dependsOn(stringUtilsCompile)
+  .tasks([
+    JarTask.from("string-utils/build/classes")
+      .to("string-utils/build/libs/string-utils.jar"),
+  ]);
+
+// Build library (compile + test + package)
+export const stringUtilsBuild = stringUtils
+  .target("build")
+  .dependsOn(stringUtilsJar, stringUtilsTest);
+
+// ============================================================================
+// APP Module
+// Depends on string-utils library and external Maven dependencies
+// ============================================================================
+
+const app = project("app");
+
+// Clean build directory
+export const appClean = app
+  .target("clean")
+  .tasks([DeleteTask.paths("app/build").recursive(true)]);
+
+// Resolve app dependencies (org.json)
+export const appResolveDeps = app
+  .target("resolve-deps")
+  .produces(appDependencies)
+  .tasks([
+    MavenDepTask.resolve(
+      "org.json:json:20230227"
+    ).into(appDependencies),
+  ]);
+
+// Compile app sources
+// Depends on: string-utils library JAR + external dependencies
+// Note: JavacTask creates output directory automatically
+export const appCompile = app
+  .target("compile")
+  .dependsOn(appClean, appResolveDeps, stringUtilsJar)
+  .tasks([
+    JavacTask.sources("app/src/main/java/com/example/app/Application.java")
+      .destination("app/build/classes")
+      .classpath(
+        appDependencies,
+        "string-utils/build/libs/string-utils.jar"  // Library module dependency
+      )
+      .sourceVersion("11")
+      .targetVersion("11"),
+  ]);
+
+// Compile app tests
+// Needs: JUnit + app dependencies + string-utils + compiled app classes
+export const appCompileTests = app
+  .target("compile-tests")
+  .dependsOn(appCompile, stringUtilsResolveDeps)
+  .tasks([
+    JavacTask.sources("app/src/test/java/com/example/app/ApplicationTest.java")
+      .destination("app/build/test-classes")
+      .classpath(
+        junitClasspath,
+        appDependencies,
+        "string-utils/build/libs/string-utils.jar",
+        "app/build/classes"
+      )
+      .sourceVersion("11")
+      .targetVersion("11"),
+  ]);
+
+// Run app tests
+export const appTest = app
+  .target("test")
+  .dependsOn(appCompileTests)
+  .tasks([
+    JavaTask.mainClass("org.junit.platform.console.ConsoleLauncher")
+      .classpath(
+        junitClasspath,
+        appDependencies,
+        "string-utils/build/libs/string-utils.jar",
+        "app/build/classes",
+        "app/build/test-classes"
+      )
+      .args([
+        "--scan-classpath",
+        "app/build/test-classes",
+        "--fail-if-no-tests",
+      ]),
+  ]);
+
+// Package app as executable JAR
+export const appJar = app
+  .target("jar")
+  .dependsOn(appCompile)
+  .tasks([
+    JarTask.from("app/build/classes")
+      .to("app/build/libs/app.jar")
+      .mainClass("com.example.app.Application"),
+  ]);
+
+// Build app (compile + test + package)
+export const appBuild = app
+  .target("build")
+  .dependsOn(appJar, appTest);
+
+// Run the application
+export const appRun = app
+  .target("run")
+  .dependsOn(appCompile)
+  .tasks([
+    JavaTask.mainClass("com.example.app.Application")
+      .classpath(
+        appDependencies,
+        "string-utils/build/libs/string-utils.jar",
+        "app/build/classes"
+      ),
+  ]);
+
+// ============================================================================
+// Execution
+// ============================================================================
+
+// Only run if this file is executed directly
+if (import.meta.main) {
+  console.log("\n=== Java Maven Project Example with Worklift ===\n");
+  console.log("This demonstrates:");
+  console.log("  • Multi-module Maven project structure");
+  console.log("  • Maven directory conventions (src/main/java, src/test/java)");
+  console.log("  • Library modules (string-utils)");
+  console.log("  • Application modules (app)");
+  console.log("  • Inter-module dependencies");
+  console.log("  • Maven dependency resolution (JUnit 5, org.json)");
+  console.log("  • Testing with JUnit 5");
+  console.log("  • JAR packaging\n");
+
+  console.log("Building string-utils library and app...\n");
+
+  // Build and test both modules, then run the application
+  // This will:
+  // 1. Clean and build string-utils library (clean → prepare → compile → test → jar)
+  // 2. Clean and resolve dependencies for app
+  // 3. Compile and run the application
+  await app.execute("run");
+
+  console.log("\n✓ Build and execution completed successfully!\n");
+  console.log("Available targets:");
+  console.log("  • string-utils:clean         - Remove library build artifacts");
+  console.log("  • string-utils:compile       - Compile library sources");
+  console.log("  • string-utils:compile-tests - Compile library tests");
+  console.log("  • string-utils:test          - Run library tests");
+  console.log("  • string-utils:jar           - Package library into JAR");
+  console.log("  • string-utils:build         - Full library build (compile + test + jar)");
+  console.log("  • app:clean                  - Remove application build artifacts");
+  console.log("  • app:compile                - Compile application sources");
+  console.log("  • app:compile-tests          - Compile application tests");
+  console.log("  • app:test                   - Run application tests");
+  console.log("  • app:jar                    - Package application into executable JAR");
+  console.log("  • app:build                  - Full app build (compile + test + jar)");
+  console.log("  • app:run                    - Run the application\n");
+}

--- a/examples/java-maven-project/string-utils/src/main/java/com/example/utils/StringUtils.java
+++ b/examples/java-maven-project/string-utils/src/main/java/com/example/utils/StringUtils.java
@@ -1,0 +1,74 @@
+package com.example.utils;
+
+/**
+ * String utility library demonstrating Maven library module conventions.
+ * This module will be used as a dependency by the app module.
+ */
+public class StringUtils {
+
+    /**
+     * Reverses a string.
+     * @param input the string to reverse
+     * @return the reversed string
+     */
+    public static String reverse(String input) {
+        if (input == null) {
+            return null;
+        }
+        return new StringBuilder(input).reverse().toString();
+    }
+
+    /**
+     * Checks if a string is a palindrome.
+     * @param input the string to check
+     * @return true if the string is a palindrome, false otherwise
+     */
+    public static boolean isPalindrome(String input) {
+        if (input == null) {
+            return false;
+        }
+        String cleaned = input.replaceAll("\\s+", "").toLowerCase();
+        return cleaned.equals(reverse(cleaned));
+    }
+
+    /**
+     * Capitalizes the first letter of each word.
+     * @param input the string to capitalize
+     * @return the capitalized string
+     */
+    public static String capitalizeWords(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+
+        String[] words = input.split("\\s+");
+        StringBuilder result = new StringBuilder();
+
+        for (int i = 0; i < words.length; i++) {
+            if (i > 0) {
+                result.append(" ");
+            }
+            String word = words[i];
+            if (!word.isEmpty()) {
+                result.append(Character.toUpperCase(word.charAt(0)));
+                if (word.length() > 1) {
+                    result.append(word.substring(1).toLowerCase());
+                }
+            }
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Counts the number of words in a string.
+     * @param input the string to count words in
+     * @return the number of words
+     */
+    public static int countWords(String input) {
+        if (input == null || input.trim().isEmpty()) {
+            return 0;
+        }
+        return input.trim().split("\\s+").length;
+    }
+}

--- a/examples/java-maven-project/string-utils/src/test/java/com/example/utils/StringUtilsTest.java
+++ b/examples/java-maven-project/string-utils/src/test/java/com/example/utils/StringUtilsTest.java
@@ -1,0 +1,42 @@
+package com.example.utils;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class demonstrating JUnit 5 testing with Maven conventions.
+ */
+public class StringUtilsTest {
+
+    @Test
+    public void testReverse() {
+        assertEquals("olleh", StringUtils.reverse("hello"));
+        assertEquals("", StringUtils.reverse(""));
+        assertNull(StringUtils.reverse(null));
+    }
+
+    @Test
+    public void testIsPalindrome() {
+        assertTrue(StringUtils.isPalindrome("racecar"));
+        assertTrue(StringUtils.isPalindrome("A man a plan a canal Panama"));
+        assertFalse(StringUtils.isPalindrome("hello"));
+        assertFalse(StringUtils.isPalindrome(null));
+    }
+
+    @Test
+    public void testCapitalizeWords() {
+        assertEquals("Hello World", StringUtils.capitalizeWords("hello world"));
+        assertEquals("Java Programming", StringUtils.capitalizeWords("JAVA PROGRAMMING"));
+        assertEquals("", StringUtils.capitalizeWords(""));
+        assertNull(StringUtils.capitalizeWords(null));
+    }
+
+    @Test
+    public void testCountWords() {
+        assertEquals(3, StringUtils.countWords("hello world test"));
+        assertEquals(1, StringUtils.countWords("hello"));
+        assertEquals(0, StringUtils.countWords(""));
+        assertEquals(0, StringUtils.countWords(null));
+        assertEquals(3, StringUtils.countWords("  multiple   spaces   here  "));
+    }
+}


### PR DESCRIPTION
This example demonstrates:
- Multi-module Maven project structure with library and app modules
- Maven directory conventions (src/main/java, src/test/java)
- Maven dependency resolution (JUnit 5, org.json)
- Inter-module dependencies (app depends on string-utils library)
- Testing with JUnit 5
- JAR packaging
- Complete build pipeline with Worklift

The example includes:
- string-utils: Reusable library module with utility functions
- app: Application module that uses the library and external dependencies
- Comprehensive README with usage instructions
- Working build script demonstrating Worklift's Java capabilities